### PR TITLE
Make field proxy public

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ use std::sync::Arc;
 use servo::compositing::compositor_thread::EventLoopWaker;
 
 pub struct GlutinEventLoopWaker {
-    proxy: Arc<glutin::EventsLoopProxy>
+    pub proxy: Arc<glutin::EventsLoopProxy>
 }
 
 impl EventLoopWaker for GlutinEventLoopWaker {


### PR DESCRIPTION
Example does not compile if this field is not public, at least not for me.

```rust
error[E0451]: field `proxy` of struct `events::GlutinEventLoopWaker` is private
  --> src/main.rs:15:9
   |
15 |         proxy: Arc::new(event_loop.create_proxy())
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ field `proxy` is private

error: aborting due to previous error
```